### PR TITLE
Switch from flask-socketio to normal socketio

### DIFF
--- a/parse_table.py
+++ b/parse_table.py
@@ -52,7 +52,7 @@ def extract_value(x):
     return x[0].text
 
 
-def convert_to_csv(filename, page_index, output_path, user_connected, capture_stdout, socketio=None, sid=None):
+def convert_to_csv(filename, page_index, output_path, user_connected, capture_stdout, sio=None, sid=None):
     im = imgread(filename)
     width, height, _ = im.shape
 
@@ -139,7 +139,7 @@ def convert_to_csv(filename, page_index, output_path, user_connected, capture_st
 
         if capture_stdout:
             # progress_bar = '⬛' * int(BAR_LENGTH * (ind / len(cont)))
-            socketio.emit('progress', {
+            sio.emit('progress', {
                 'stdout': int(ind / len(cont) * 100),
                 'index': page_index
             }, room=sid)
@@ -147,7 +147,7 @@ def convert_to_csv(filename, page_index, output_path, user_connected, capture_st
         if user_connected is not None and not user_connected[sid]:
             break
 
-    # socketio.emit('send_table', {
+    # sio.emit('send_table', {
     #     'table': table_array,
     # }, room=sid)
 

--- a/static/main.css
+++ b/static/main.css
@@ -116,6 +116,10 @@ img {
     float: left;
 }
 
+.loading {
+    font-size: 20px;
+}
+
 .page_index {
     background-color: #22272e;
     font-size: 36px;

--- a/static/main.js
+++ b/static/main.js
@@ -1,4 +1,5 @@
-const socket = io("ws://" + window.location.hostname + ":" + window.location.port);
+const socket = io("ws://" + window.location.hostname + ":1500");
+
 let start_time, processing_in_progress = false;
 let form = document.forms.submit_link;
 


### PR DESCRIPTION
So I found out the reason for all of my troubles with missing socket.io requests. Flask-socketio does not provide easy access to client's **sid** (unique index). The one that I was using was not static and changed during program execution which made many requests not reach the target.
So I just trashed flask-socketio and rewrote to plain python version of socketio. Works great!