### PR TITLE
Fix urllib.urlretrieve 403: Forbidden

### DIFF
--- a/recognise.py
+++ b/recognise.py
@@ -41,6 +41,10 @@ args = vars(ap.parse_args())
 pbar = None
 MAX_BUFFER_SIZE = 50 * 1000 * 1000  # 50 MB
 
+# urlib request options
+user_agent = 'Mozilla/5.0'
+headers = {'User-Agent': user_agent,}
+
 # Create a Socket.IO server
 sio = socketio.AsyncServer(async_mode='aiohttp', cors_allowed_origins=cors_allowed_origins,
                            maxHttpBufferSize=MAX_BUFFER_SIZE, async_handlers=True)
@@ -72,7 +76,8 @@ class Rect:
 
 def check_if_url_exists(url):
     try:
-        u = urllib.request.urlopen(url)
+        test_request = urllib.request.Request(url, None, headers)
+        u = urllib.request.urlopen(test_request)
         u.close()
         return True
 
@@ -193,6 +198,10 @@ async def process_by_link(link, quality, limit, sid, download_on_finish):
 
     pdf_file = os.path.join(prefix_path, f"output/processed_documents/remote_document_{process_index}.pdf")
     if check_if_url_exists(link):
+        opener = urllib.request.build_opener()
+        opener.addheaders = [('User-agent', 'Mozilla/5.0')]
+        urllib.request.install_opener(opener)
+
         urllib.request.urlretrieve(link, pdf_file)
     else:
         await emit_message('There is a problem loading file from this link. Check if it is correct\n', sid)


### PR DESCRIPTION
Example link that didn't work before and gave 403
https://region.broker/upload/iblock/ead/bfo_na_31.12.2022.pdf